### PR TITLE
Fix type instability due to mapslices in colorvec partial generation

### DIFF
--- a/src/differentiation/compute_jacobian_ad.jl
+++ b/src/differentiation/compute_jacobian_ad.jl
@@ -37,12 +37,8 @@ function ForwardColorJacCache(f,x,_chunksize = nothing;
         fx = similar(t)
         _dx = similar(x)
     else
-        pi = first(p) #perform trim (length(dx)<length(x)) or padding (length(dx)>length(x)) to first(p)
-        if length(dx)>length(x)
-            pi = vcat(pi,reshape(mapslices(Tuple,zeros(Bool,length(first(pi)),length(dx)-length(x)),dims=1),:))
-        else
-            pi = pi[1:length(dx)]
-        end
+        tup = first(first(p)) .* false
+        pi = adapt.(typeof(dx),[tup for i in 1:length(dx)])
         fx = reshape(Dual{ForwardDiff.Tag(f,eltype(vec(x)))}.(vec(dx),pi),size(dx)...)
         _dx = dx
     end


### PR DESCRIPTION
```julia
using BenchmarkTools, SparseArrays, SparseDiffTools, ForwardDiff
function f!(H, x)
    for n in 1:length(H)
        if isodd(n)
            H[n] = 2*x[1]
        else
            H[n] = 3*x[2]
        end
    end
end
H = zeros(10000)
x = 5.0 * ones(200)
f!(H, x)

pattern = sparse(vcat(collect(1:2:10000), collect(2:2:10000)), vcat(repeat([1], 5000), repeat([2], 5000)), 1, length(H), length(x))
jac = Float64.(sparse(pattern))
colors = matrix_colors(jac)
@btime forwarddiff_color_jacobian!(jac, f!, x, colorvec = colors);
```

goes from `9.993 ms (136398 allocations: 4.46 MiB)` to `605.200 μs (696 allocations: 284.89 KiB)`