### PR TITLE
reduce time complexity of matrix2graph

### DIFF
--- a/src/coloring/matrix2graph.jl
+++ b/src/coloring/matrix2graph.jl
@@ -1,4 +1,31 @@
 """
+        _cols_by_rows(rows_index,cols_index)
+
+Returns a vector of rows where each row contains
+a vector of its column indices.
+"""
+function _cols_by_rows(rows_index,cols_index)
+    nrows = maximum(rows_index)
+    cols_by_rows = [eltype(rows_index)[] for _ in 1:nrows]
+    for (i,j) in zip(rows_index,cols_index)
+        push!(cols_by_rows[i],j)
+    end
+    return cols_by_rows
+end
+
+
+"""
+        _rows_by_cols(rows_index,cols_index)
+
+Returns a vector of columns where each column contains
+a vector of its row indices.
+"""
+function _rows_by_cols(rows_index,cols_index)
+    return _cols_by_rows(cols_index,rows_index)
+end
+
+
+"""
         matrix2graph(sparse_matrix, [partition_by_rows::Bool=true])
 
 A utility function to generate a graph from input
@@ -19,22 +46,24 @@ function matrix2graph(sparse_matrix::SparseMatrixCSC{<:Number, Int}, partition_b
     inner = SimpleGraph(num_vtx)
 
     if partition_by_rows
-        @inbounds for i in eachindex(rows_index)
-            cur_row = rows_index[i]
-            for j in 1:(i-1)
-                next_row = rows_index[j]
-                if cols_index[i] == cols_index[j] && cur_row != next_row
-                    add_edge!(inner, cur_row, next_row)
+        rows_by_cols = _rows_by_cols(rows_index,cols_index)
+        @inbounds for (cur_row,cur_col) in zip(rows_index,cols_index)
+            if !isempty(rows_by_cols[cur_col])
+                for next_row in rows_by_cols[cur_col]
+                    if next_row < cur_row 
+                        add_edge!(inner, cur_row, next_row)
+                    end
                 end
             end
         end
     else
-        @inbounds for i in eachindex(cols_index)
-            cur_col = cols_index[i]
-            for j in 1:(i-1)
-                next_col = cols_index[j]
-                if rows_index[i] == rows_index[j] && cur_col != next_col
-                    add_edge!(inner, cur_col, next_col)
+        cols_by_rows = _cols_by_rows(rows_index,cols_index)
+        @inbounds for (cur_row,cur_col) in zip(rows_index,cols_index)
+            if !isempty(cols_by_rows[cur_row])
+                for next_col in cols_by_rows[cur_row]
+                    if next_col < cur_col 
+                        add_edge!(inner, cur_col, next_col)
+                    end
                 end
             end
         end


### PR DESCRIPTION
This uses an intermediate structure to arrange the indices of the columns of the matrix by rows and avoid the nested for-loops of complexity O(nnz^2).

Benchmark #93 on my local machine, old version :
```
julia> @time matrix2graph(jacsparsity, false)
447.022331 seconds (1.02 M allocations: 100.974 MiB, 0.01% gc time)
```
New version :
```
julia> @time matrix2graph(jacsparsity, false)
  0.158604 seconds (1.18 M allocations: 116.212 MiB, 24.89% gc time)
```

_[my first Julia PR ! :smiley: ]_
