### PR TITLE
Initialize result for D1 coloring

### DIFF
--- a/src/coloring/greedy_d1_coloring.jl
+++ b/src/coloring/greedy_d1_coloring.jl
@@ -12,6 +12,7 @@ function color_graph(g::VSafeGraph, alg::GreedyD1Color)
     result = zeros(Int, v)
     result[1] = 1
     available = BitVector(undef, v)
+    fill!(available, false)
     for i = 2:v
         for j in inneighbors(g, i)
             if result[j] != 0


### PR DESCRIPTION
Once under a blue moon the 1D coloring returns an invalid color at `result[2]`. This happens very very rarely. Below is an example we caught in the CI. Rerunning the test fixes the problem. I have no proof, but looking at the code it seems that in the first iteration of the outer `for` loop (`i=2`),  `available` is uninitialized, which then could lead to a wrong entry before `available` is filled at the end of the loop. In that case, this would be the fix.

```
coloring = [1, 65, 1, 2, 3, 1, 3, 4, 5, 4, 5, 6, 2, 4, 2, 5, 2, 1, 3, 2, 1, 3, 2, 1, 4, 1, 2, 3, 3, 2, 1, 3, 4, 2, 1, 3, 4, 2, 4, 1, 2, 4, 2, 1, 1, 3, 5, 7, 1, 2, 1, 2, 4, 7, 3, 5, 6, 7, 8, 8, 9, 10, 8, 11, 7, 9, 5, 4, 6, 5, 8, 6, 5, 7, 8, 6, 7, 4, 4, 5, 6, 7, 8, 5, 6, 9, 11, 7, 7, 8, 6, 7, 6, 3, 7, 6, 12, 13, 3, 5, 6, 5, 8, 11, 10, 11]
```