### PR TITLE
Add method to mirror ForwardDiff's syntax for writing Jacobian of an oop function to an allocated matrix

### DIFF
--- a/src/differentiation/compute_jacobian_ad.jl
+++ b/src/differentiation/compute_jacobian_ad.jl
@@ -189,7 +189,11 @@ function forwarddiff_color_jacobian(J::SparseMatrixCSC{<:Number},f,x::AbstractAr
                 cols_index_c = cols_index[pick_inds]
                 Ji = sparse(rows_index_c, cols_index_c, dx[rows_index_c],nrows,ncols)
                 # J = J + Ji
-                J .+= Ji
+                if j == 1 && i == 1
+                    J .= Ji # overwrite pre-allocated matrix
+                else
+                    J .+= Ji
+                end
                 color_i += 1
                 (color_i > maxcolor) && return J
             end
@@ -199,7 +203,11 @@ function forwarddiff_color_jacobian(J::SparseMatrixCSC{<:Number},f,x::AbstractAr
                 (col_index > ncols) && return J
                 Ji = mapreduce(i -> i==col_index ? partials.(vec(fx), j) : adapt(parameterless_type(J),zeros(eltype(J),nrows)), hcat, 1:ncols)
                 # J = J + (size(Ji)!=size(J) ? reshape(Ji,size(J)) : Ji) #branch when size(dx) == (1,) => size(Ji) == (1,) while size(J) == (1,1)
-                J .+= (size(Ji)!=size(J) ? reshape(Ji,size(J)) : Ji) #branch when size(dx) == (1,) => size(Ji) == (1,) while size(J) == (1,1)
+                if j == 1 && i == 1
+                    J .= (size(Ji)!=size(J) ? reshape(Ji,size(J)) : Ji) # overwrite pre-allocated matrix
+                else
+                    J .+= (size(Ji)!=size(J) ? reshape(Ji,size(J)) : Ji) #branch when size(dx) == (1,) => size(Ji) == (1,) while size(J) == (1,1)
+                end
             end
         end
     end

--- a/src/differentiation/compute_jacobian_ad.jl
+++ b/src/differentiation/compute_jacobian_ad.jl
@@ -76,7 +76,7 @@ end
     if dx isa Nothing
         dx = f(x)
     end
-    forwarddiff_color_jacobian(f,x,ForwardColorJacCache(f,x,chunksize,dx=dx,colorvec=colorvec,sparsity=sparsity),jac_prototype)
+    return forwarddiff_color_jacobian(f,x,ForwardColorJacCache(f,x,chunksize,dx=dx,colorvec=colorvec,sparsity=sparsity),jac_prototype)
 end
 
 @inline function forwarddiff_color_jacobian(J::AbstractArray{<:Number}, f,
@@ -90,7 +90,7 @@ end
         cfg = chunksize === nothing ? ForwardDiff.JacobianConfig(f, x) : ForwardDiff.JacobianConfig(f, x, ForwardDiff.Chunk(getsize(chunksize)))
         return ForwardDiff.jacobian(f, x, cfg)
     end
-    forwarddiff_color_jacobian(J,f,x,ForwardColorJacCache(f,x,chunksize,dx=dx,colorvec=colorvec,sparsity=sparsity))
+    return forwarddiff_color_jacobian(J,f,x,ForwardColorJacCache(f,x,chunksize,dx=dx,colorvec=colorvec,sparsity=sparsity))
 end
 
 function forwarddiff_color_jacobian(f,x::AbstractArray{<:Number},jac_cache::ForwardColorJacCache,jac_prototype=nothing)
@@ -103,7 +103,7 @@ function forwarddiff_color_jacobian(f,x::AbstractArray{<:Number},jac_cache::Forw
 
         J = jac_prototype isa Nothing ? (sparsity isa Nothing ? false .* vec(dx) .* vecx' :
                                          zeros(eltype(x),size(sparsity))) : zero(jac_prototype)
-        forwarddiff_color_jacobian(J, f, x, jac_cache)
+        return forwarddiff_color_jacobian(J, f, x, jac_cache)
     else
         return forwarddiff_color_jacobian_immutable(f, x, jac_cache, jac_prototype)
     end
@@ -173,7 +173,7 @@ function forwarddiff_color_jacobian(J::AbstractMatrix{<:Number},f,x::AbstractArr
             end
         end
     end
-    J
+    return J
 end
 
 # When J is immutable, this version of forwarddiff_color_jacobian will avoid mutating J
@@ -230,7 +230,7 @@ function forwarddiff_color_jacobian_immutable(f,x::AbstractArray{<:Number},jac_c
             end
         end
     end
-    J
+    return J
 end
 
 function forwarddiff_color_jacobian!(J::AbstractMatrix{<:Number},

--- a/src/differentiation/compute_jacobian_ad.jl
+++ b/src/differentiation/compute_jacobian_ad.jl
@@ -83,12 +83,13 @@ end
                 colorvec = 1:length(x),
                 sparsity = nothing,
                 jac_prototype = nothing,
-                chunksize = nothing) # Note no dx keyword b/c can infer Jacobian's size via J
+                chunksize = nothing,
+                dx = similar(x, size(J, 1))) #if dx is nothing, we will estimate dx at the cost of a function call
     if sparsity === nothing && jac_prototype === nothing || !ArrayInterface.ismutable(x)
         cfg = chunksize === nothing ? ForwardDiff.JacobianConfig(f, x) : ForwardDiff.JacobianConfig(f, x, ForwardDiff.Chunk(getsize(chunksize)))
         return ForwardDiff.jacobian(f, x, cfg)
     end
-    forwarddiff_color_jacobian(J,f,x,ForwardColorJacCache(f,x,chunksize,dx=similar(x,size(J, 1)),colorvec=colorvec,sparsity=sparsity),jac_prototype)
+    forwarddiff_color_jacobian(J,f,x,ForwardColorJacCache(f,x,chunksize,dx=dx,colorvec=colorvec,sparsity=sparsity),jac_prototype)
 end
 
 function forwarddiff_color_jacobian(f,x::AbstractArray{<:Number},jac_cache::ForwardColorJacCache,jac_prototype=nothing)

--- a/src/differentiation/compute_jacobian_ad.jl
+++ b/src/differentiation/compute_jacobian_ad.jl
@@ -68,16 +68,14 @@ end
                 jac_prototype = nothing,
                 chunksize = nothing,
                 dx = sparsity === nothing && jac_prototype === nothing ? nothing : copy(x)) #if dx is nothing, we will estimate dx at the cost of a function call
-    @show typeof(x)
 
-    if sparsity === nothing && jac_prototype === nothing || !ArrayInterface.ismutable(x)
+    if sparsity === nothing && jac_prototype === nothing
         cfg = chunksize === nothing ? ForwardDiff.JacobianConfig(f, x) : ForwardDiff.JacobianConfig(f, x, ForwardDiff.Chunk(getsize(chunksize)))
         return ForwardDiff.jacobian(f, x, cfg)
     end
     if dx isa Nothing
         dx = f(x)
     end
-    @show "Line 80"
     forwarddiff_color_jacobian(f,x,ForwardColorJacCache(f,x,chunksize,dx=dx,colorvec=colorvec,sparsity=sparsity),jac_prototype)
 end
 
@@ -88,12 +86,11 @@ end
                 jac_prototype = nothing,
                 chunksize = nothing,
                 dx = similar(x, size(J, 1))) #dx kwarg can be used to avoid re-allocating dx every time
-    if sparsity === nothing && jac_prototype === nothing || !ArrayInterface.ismutable(x)
+    if sparsity === nothing && jac_prototype === nothing
         cfg = chunksize === nothing ? ForwardDiff.JacobianConfig(f, x) : ForwardDiff.JacobianConfig(f, x, ForwardDiff.Chunk(getsize(chunksize)))
         return ForwardDiff.jacobian(f, x, cfg)
     end
-    @show "Line 95"
-    forwarddiff_color_jacobian(J,f,x,ForwardColorJacCache(f,x,chunksize,dx=dx,colorvec=colorvec,sparsity=sparsity),jac_prototype)
+    forwarddiff_color_jacobian(J,f,x,ForwardColorJacCache(f,x,chunksize,dx=dx,colorvec=colorvec,sparsity=sparsity))
 end
 
 function forwarddiff_color_jacobian(f,x::AbstractArray{<:Number},jac_cache::ForwardColorJacCache,jac_prototype=nothing)
@@ -103,13 +100,10 @@ function forwarddiff_color_jacobian(f,x::AbstractArray{<:Number},jac_cache::Forw
 
     J = jac_prototype isa Nothing ? (sparsity isa Nothing ? false .* vec(dx) .* vecx' : zeros(eltype(x),size(sparsity))) : zero(jac_prototype)
 
-    @show typeof(J)
     if ArrayInterface.ismutable(J) # Whenever J is mutable, we mutate it to avoid allocations
-        @show "Line 108"
-        forwarddiff_color_jacobian(J, f, x, jac_cache, jac_prototype)
+        forwarddiff_color_jacobian(J, f, x, jac_cache)
     else
-        @show "Line 111"
-        forwarddiff_color_jacobian_immutable(J, f, x, jac_cache, jac_prototype)
+        forwarddiff_color_jacobian_immutable(J, f, x, jac_cache)
     end
 end
 

--- a/test/test_ad.jl
+++ b/test/test_ad.jl
@@ -115,10 +115,9 @@ _J1 = forwarddiff_color_jacobian(oopf, x, colorvec = repeat(1:3,10), sparsity = 
 @test _J1 ≈ J
 @test fcalls == 1
 
-
 #oop with in-place Jacobian
 fcalls = 0
-_oop_jacout = spzeros(size(J)...)
+_oop_jacout = sparse(1.01 .* J) # want to be nonzero to check that the pre-allocated matrix is overwritten properly
 forwarddiff_color_jacobian(_oop_jacout, oopf, x; colorvec = repeat(1:3,10), sparsity = _J, jac_prototype = _J)
 @test _oop_jacout ≈ J
 @test typeof(_oop_jacout) == typeof(_J)

--- a/test/test_ad.jl
+++ b/test/test_ad.jl
@@ -117,7 +117,6 @@ _J1 = forwarddiff_color_jacobian(oopf, x, colorvec = repeat(1:3,10), sparsity = 
 
 
 #oop with in-place Jacobian
-x = rand(30)
 fcalls = 0
 _oop_jacout = spzeros(size(J)...)
 forwarddiff_color_jacobian(_oop_jacout, oopf, x; colorvec = repeat(1:3,10), sparsity = _J, jac_prototype = _J)

--- a/test/test_ad.jl
+++ b/test/test_ad.jl
@@ -124,9 +124,11 @@ forwarddiff_color_jacobian(_oop_jacout, oopf, x; colorvec = repeat(1:3,10), spar
 @test typeof(_oop_jacout) == typeof(_J)
 @test fcalls == 1
 
-_oop_jacout = BandedMatrix(1.01 .* _oop_jacout) # check w/BandedMatrix instead of sparse
+# BandedMatrix
+_oop_jacout = BandedMatrix(-1 => diag(J, -1) .* 1.01, 0 => diag(J, 0) .* 1.01,
+                           1 => diag(J, 1) .* 1.01) # check w/BandedMatrix instead of sparse
 fcalls = 0
-forwarddiff_color_jacobian(_oop_jacout, oopf, x; colorvec = repeat(1:3,10), sparsity = _J, jac_prototype = _J)
+forwarddiff_color_jacobian(_oop_jacout, oopf, x; colorvec = repeat(1:3,10), sparsity = _J)
 @test _oop_jacout ≈ J
 @test isa(_oop_jacout, BandedMatrix)
 @test fcalls == 1

--- a/test/test_ad.jl
+++ b/test/test_ad.jl
@@ -238,3 +238,12 @@ f(x) = x
 J = forwarddiff_color_jacobian(f,x)
 @test J isa SArray
 @test J ≈ SMatrix{1,1}([1.])
+
+@info "6"
+#oop with in-place Jacobian
+fcalls = 0
+_oop_jacout = spzeros(size(J)...)
+forwarddiff_color_jacobian(_oop_jacout, oopf, x; colorvec = repeat(1:3,10), sparsity = _J, jac_prototype = _J)
+@test _oop_jacout ≈ J
+@test typeof(_oop_jacout) == typeof(_J)
+@test fcalls == 1

--- a/test/test_ad.jl
+++ b/test/test_ad.jl
@@ -115,6 +115,16 @@ _J1 = forwarddiff_color_jacobian(oopf, x, colorvec = repeat(1:3,10), sparsity = 
 @test _J1 ≈ J
 @test fcalls == 1
 
+
+#oop with in-place Jacobian
+x = rand(30)
+fcalls = 0
+_oop_jacout = spzeros(size(J)...)
+forwarddiff_color_jacobian(_oop_jacout, oopf, x; colorvec = repeat(1:3,10), sparsity = _J, jac_prototype = _J)
+@test _oop_jacout ≈ J
+@test typeof(_oop_jacout) == typeof(_J)
+@test fcalls == 1
+
 @info "4th passed"
 
 fcalls = 0
@@ -238,12 +248,3 @@ f(x) = x
 J = forwarddiff_color_jacobian(f,x)
 @test J isa SArray
 @test J ≈ SMatrix{1,1}([1.])
-
-@info "6"
-#oop with in-place Jacobian
-fcalls = 0
-_oop_jacout = spzeros(size(J)...)
-forwarddiff_color_jacobian(_oop_jacout, oopf, x; colorvec = repeat(1:3,10), sparsity = _J, jac_prototype = _J)
-@test _oop_jacout ≈ J
-@test typeof(_oop_jacout) == typeof(_J)
-@test fcalls == 1

--- a/test/test_ad.jl
+++ b/test/test_ad.jl
@@ -3,6 +3,7 @@ using ForwardDiff: Dual, jacobian
 using SparseArrays, Test
 using LinearAlgebra
 using BlockBandedMatrices
+using BandedMatrices
 using StaticArrays
 
 fcalls = 0
@@ -121,6 +122,13 @@ _oop_jacout = sparse(1.01 .* J) # want to be nonzero to check that the pre-alloc
 forwarddiff_color_jacobian(_oop_jacout, oopf, x; colorvec = repeat(1:3,10), sparsity = _J, jac_prototype = _J)
 @test _oop_jacout ≈ J
 @test typeof(_oop_jacout) == typeof(_J)
+@test fcalls == 1
+
+_oop_jacout = BandedMatrix(1.01 .* _oop_jacout) # check w/BandedMatrix instead of sparse
+fcalls = 0
+forwarddiff_color_jacobian(_oop_jacout, oopf, x; colorvec = repeat(1:3,10), sparsity = _J, jac_prototype = _J)
+@test _oop_jacout ≈ J
+@test isa(_oop_jacout, BandedMatrix)
 @test fcalls == 1
 
 @info "4th passed"


### PR DESCRIPTION
In ForwardDiff.jl, there is the ability to define an out-of-place function `f(x)` and autodiff it using
```
ForwardDiff.jacobian!(jac, f, x)
```
where `jac` is allocated outside of `ForwardDiff.jacobian!`. I have a specific use case where it'd be nice to have such a functionality in SparseDiffTools.jl and have implemented it. The tests should pass.

You may notice that I've defined
```
function forwarddiff_color_jacobian(J::SparseMatrixCSC{<:Number},f,x::AbstractArray{<:Number},jac_cache::ForwardColorJacCache,jac_prototype=nothing)
```
in addition to
```
function forwarddiff_color_jacobian(J::AbstractArray{<:Number},f,x::AbstractArray{<:Number},jac_cache::ForwardColorJacCache,jac_prototype=nothing)
```
I'm not too familiar with StaticArrays.jl, but I was unable to get one of the StaticArrays tests to pass when I used
```
J .+= (size(Ji)!=size(J) ? reshape(Ji,size(J)) : Ji)
```
instead of
```
J = J + (size(Ji)!=size(J) ? reshape(Ji,size(J)) : Ji)
```
To ensure I can mirror the function from ForwardDiff, I need the first line of code to work, but it seems to cause an error for StaticArrays. 

Thus, to avoid changing the behavior of the package by too much, I just defined a version of `forwarddiff_color_jacobian` specifically when `J` is a sparse matrix, since it should be safe to do `J .+= ...` The more general version of `forwarddiff_color_jacobian` continues to use `J += ...` If you think that it'd be better to switch the two (i.e. write a `forwarddiff_color_jacobian(J::StaticArray{<: Number}, ...)` and using `J .+= ..` for the general version), then I'm happy to update the code.