### PR TITLE
Make inference's job much easier by avoiding `map`

### DIFF
--- a/src/differentiation/compute_jacobian_ad.jl
+++ b/src/differentiation/compute_jacobian_ad.jl
@@ -307,7 +307,7 @@ function forwarddiff_color_jacobian!(J::AbstractMatrix{<:Number},
 
         if vect isa Array
             @inbounds @simd ivdep for j in eachindex(vect)
-                vect = Dual{typeof(ForwardDiff.Tag(f,eltype(vecx)))}(vecx[j], partial_i[j])
+                vect[j] = Dual{typeof(ForwardDiff.Tag(f,eltype(vecx)))}(vecx[j], partial_i[j])
             end
         else
             vect .= Dual{typeof(ForwardDiff.Tag(f,eltype(vecx)))}.(vecx, partial_i)

--- a/src/differentiation/compute_jacobian_ad.jl
+++ b/src/differentiation/compute_jacobian_ad.jl
@@ -59,8 +59,8 @@ function generate_chunked_partials(x,colorvec,::Val{chunksize}) where chunksize
 
     # partials = colorvec .== (1:maxcolor)'
     partials = BitMatrix(undef, length(colorvec), maxcolor)
-    for j in 1:length(colorvec), i in 1:maxcolor
-        partials[i,j] = colorvec[j] == i
+    for i in 1:maxcolor, j in 1:length(colorvec)
+        partials[j,i] = colorvec[j] == i
     end
 
     padding_matrix = BitMatrix(undef, length(x), padding_size)

--- a/src/differentiation/compute_jacobian_ad.jl
+++ b/src/differentiation/compute_jacobian_ad.jl
@@ -66,9 +66,11 @@ function generate_chunked_partials(x,colorvec,::Val{chunksize}) where chunksize
     padding_matrix = BitMatrix(undef, length(x), padding_size)
     partials = hcat(partials, padding_matrix)
 
+
+    #chunked_partials = map(i -> Tuple.(eachrow(partials[:,(i-1)*chunksize+1:i*chunksize])),1:num_of_chunks)
     chunked_partials = Vector{Vector{NTuple{chunksize,eltype(x)}}}(undef, num_of_chunks)
     for i in 1:num_of_chunks
-        tmp = Vector{NTuple{chunksize,eltype(x)}}(undef, chunksize)
+        tmp = Vector{NTuple{chunksize,eltype(x)}}(undef, size(partials,1))
         for j in 1:size(partials,1)
             tmp[j] = Tuple(@view partials[j,(i-1)*chunksize+1:i*chunksize])
         end


### PR DESCRIPTION
Before:

```julia
function lorenz(du,u,p,t)
 du[1] = 10.0(u[2]-u[1])
 du[2] = u[1]*(28.0-u[3]) - u[2]
 du[3] = u[1]*u[2] - (8/3)*u[3]
end

u0 = [1.0;0.0;0.0]
tspan = (0.0,100.0)

using OrdinaryDiffEq, SnoopCompile
prob = ODEProblem(lorenz,u0,tspan)
alg = Rodas5()
tinf = @snoopi_deep solve(prob,alg)
```