### PR TITLE
Modify `auto_jacvec` for compatibility with Zygote

### DIFF
--- a/src/differentiation/jaches_products.jl
+++ b/src/differentiation/jaches_products.jl
@@ -9,7 +9,8 @@ function auto_jacvec!(dy, f, x, v,
     dy .= partials.(cache2, 1)
 end
 function auto_jacvec(f, x, v)
-    partials.(f(Dual{DeivVecTag}.(x, v)), 1)
+    fval = f(map((xi, vi) -> Dual{typeof(ForwardDiff.Tag(f,eltype(x)))}(xi, vi), x, v))
+    map(u -> partials(u)[1], fval)
 end
 
 function num_jacvec!(dy,f,x,v,cache1 = similar(v),


### PR DESCRIPTION
This fixes one of the problems encountered in https://github.com/SciML/DiffEqFlux.jl/pull/614 : Zygote seems to have trouble differentiating through this broadcast, so I've changed it to `map`. Additionally a different tag is used, more similar to what ForwardDiff.jl does. Related PR: https://github.com/JuliaDiff/SparseDiffTools.jl/pull/155 .