### PR TITLE
Remove numargs usage

### DIFF
--- a/src/differentiation/vecjac_products.jl
+++ b/src/differentiation/vecjac_products.jl
@@ -1,25 +1,3 @@
-function _numargs(f)
-    typ = Tuple{Any, Val{:analytic}, Vararg}
-    typ2 = Tuple{Any, Type{Val{:analytic}}, Vararg} # This one is required for overloaded types
-    typ3 = Tuple{Any, Val{:jac}, Vararg}
-    typ4 = Tuple{Any, Type{Val{:jac}}, Vararg} # This one is required for overloaded types
-    typ5 = Tuple{Any, Val{:tgrad}, Vararg}
-    typ6 = Tuple{Any, Type{Val{:tgrad}}, Vararg} # This one is required for overloaded types
-    numparam = maximum([(m.sig<:typ || m.sig<:typ2 || m.sig<:typ3 || m.sig<:typ4 || m.sig<:typ5 || m.sig<:typ6) ? 0 : num_types_in_tuple(m.sig) for m in methods(f)])
-    return (numparam-1) #-1 in v0.5 since it adds f as the first parameter
-end
-
-
-#Get the number of parameters of a Tuple type, i.e. the number of fields.
-
-function num_types_in_tuple(sig)
-  length(sig.parameters)
-end
-
-function num_types_in_tuple(sig::UnionAll)
-  length(Base.unwrap_unionall(sig).parameters)
-end
-    
 function num_vecjac!(
     du,
     f,
@@ -29,10 +7,6 @@ function num_vecjac!(
     cache2 = similar(v);
     compute_f0 = true,
 )
-    if _numargs(f) != 2
-        du .= num_jacvec(f, x, v)
-        return du
-    end
     compute_f0 && (f(cache1, x))
     T = eltype(x)
     # Should it be min? max? mean?


### PR DESCRIPTION
This just doesn't match the JuliaDiff style which is that the function call is defined by the function. I.e. out of place calls use out of place functions and in-place calls use in-place functions. This mixed it up which shouldn't be allowed in the API.