### PR TITLE
Remove inline and specialize the function evaluations

### DIFF
--- a/test/test_acyclic.jl
+++ b/test/test_acyclic.jl
@@ -4,7 +4,7 @@ using Graphs: SimpleGraph
 using Test
 
 using Random
-Random.seed!(100)
+Random.seed!(90)
 
 # println("Starting acyclic coloring test...")
 #= Test data =#


### PR DESCRIPTION
I believe the reason for the inlining was because the functions weren't specializing, and so this will fix that. Improves this ODE example a ton:

```julia
function rober2(u,p,t)
  y₁,y₂,y₃ = u
  k₁,k₂,k₃ = p
  du1 = -k₁*y₁+k₃*y₂*y₃
  du2 =  k₁*y₁-k₂*y₂^2-k₃*y₂*y₃
  du3 =  k₂*y₂^2
  SA[du1,du2,du3]
end
prob2 = ODEProblem{false}(rober2,SA[1.0,0.0,0.0],(0.0,1e5),SA[0.04,3e7,1e4])
@btime sol = solve(prob2,Rosenbrock23(),save_everystep=false)

```