### PR TITLE
ntuple for inference

### DIFF
--- a/src/differentiation/compute_jacobian_ad.jl
+++ b/src/differentiation/compute_jacobian_ad.jl
@@ -52,7 +52,7 @@ function ForwardColorJacCache(f::F,x,_chunksize = nothing;
 end
 
 generate_chunked_partials(x,colorvec,N::Integer) = generate_chunked_partials(x,colorvec,Val(N))
-function generate_chunked_partials(x,colorvec,::Val{chunksize}) where chunksize
+function generate_chunked_partials(x,colorvec,cs::Val{chunksize}) where chunksize
     maxcolor = maximum(colorvec)
     num_of_chunks = Int(ceil(maxcolor / chunksize))
     padding_size = (chunksize - (maxcolor % chunksize)) % chunksize
@@ -72,7 +72,7 @@ function generate_chunked_partials(x,colorvec,::Val{chunksize}) where chunksize
     for i in 1:num_of_chunks
         tmp = Vector{NTuple{chunksize,eltype(x)}}(undef, size(partials,1))
         for j in 1:size(partials,1)
-            tmp[j] = Tuple(@view partials[j,(i-1)*chunksize+1:i*chunksize])
+            tmp[j] = ntuple(k->partials[j,(i-1)*chunksize+k],cs)
         end
         chunked_partials[i] = tmp
     end

--- a/src/differentiation/compute_jacobian_ad.jl
+++ b/src/differentiation/compute_jacobian_ad.jl
@@ -72,7 +72,9 @@ function generate_chunked_partials(x,colorvec,cs::Val{chunksize}) where chunksiz
     for i in 1:num_of_chunks
         tmp = Vector{NTuple{chunksize,eltype(x)}}(undef, size(partials,1))
         for j in 1:size(partials,1)
-            tmp[j] = ntuple(k->partials[j,(i-1)*chunksize+k],cs)
+            tmp[j] = ntuple(let partials=partials, i=i, j=j, chunksize=chunksize
+                k->partials[j,(i-1)*chunksize+k]
+            end, cs)
         end
         chunked_partials[i] = tmp
     end


### PR DESCRIPTION
On this example:

```julia
using DifferentialEquations, SnoopCompile

function lorenz(du,u,p,t)
 du[1] = 10.0(u[2]-u[1])
 du[2] = u[1]*(28.0-u[3]) - u[2]
 du[3] = u[1]*u[2] - (8/3)*u[3]
end

u0 = [1.0;0.0;0.0]
tspan = (0.0,100.0)
prob = ODEProblem(lorenz,u0,tspan)
alg = Rodas5(chunk_size = Val{3}())
tinf = @snoopi_deep solve(prob,alg)
solve(prob,alg)
```

we saw just two inference triggers:

```julia
julia> itrigs = inference_triggers(tinf)
2-element Vector{InferenceTrigger}:
 Inference triggered to call setindex!(::Vector{Tuple{Float64, Float64, Float64}}, ::Tuple{Bool, Bool, Bool}, ::Int64) from generate_chunked_partials (C:\Users\accou\.julia\dev\SparseDiffTools\src\differentiation\compute_jacobian_ad.jl:75) with specialization SparseDiffTools.generate_chunked_partials(::Vector{Float64}, ::UnitRange{Int64}, ::Val{3})
 Inference triggered to call OrdinaryDiffEq.jacobian2W!(::Matrix{Float64}, ::LinearAlgebra.UniformScaling{Bool}, ::Float64, ::Matrix{Float64}, ::Bool) called from toplevel
```

The second one is clear: okay, just use ntuple on like 75 right? So I did that, and it made the function more type-unstable? Look at the itrigs after that:

```julia
julia> itrigs = inference_triggers(tinf)
6-element Vector{InferenceTrigger}:
 Inference triggered to call hcat(::BitMatrix, ::BitMatrix) from generate_chunked_partials (C:\Users\accou\.julia\dev\SparseDiffTools\src\differentiation\compute_jacobian_ad.jl:67) with specialization SparseDiffTools.generate_chunked_partials(::Vector{Float64}, ::UnitRange{Int64}, ::Val{3})
 Inference triggered to call Vector{Tuple{Float64, Float64, Float64}}(::UndefInitializer, ::Int64) from generate_chunked_partials (C:\Users\accou\.julia\dev\SparseDiffTools\src\differentiation\compute_jacobian_ad.jl:73) with specialization SparseDiffTools.generate_chunked_partials(::Vector{Float64}, ::UnitRange{Int64}, ::Val{3})
 Inference triggered to call ntuple(::SparseDiffTools.var"#15#16"{3, Int64, Int64}, ::Val{3}) from generate_chunked_partials (C:\Users\accou\.julia\dev\SparseDiffTools\src\differentiation\compute_jacobian_ad.jl:75) with specialization SparseDiffTools.generate_chunked_partials(::Vector{Float64}, ::UnitRange{Int64}, ::Val{3})
 Inference triggered to call setindex!(::Vector{Tuple{Float64, Float64, Float64}}, ::Tuple{Bool, Bool, Bool}, ::Int64) from generate_chunked_partials (C:\Users\accou\.julia\dev\SparseDiffTools\src\differentiation\compute_jacobian_ad.jl:75) with specialization SparseDiffTools.generate_chunked_partials(::Vector{Float64}, ::UnitRange{Int64}, ::Val{3})
 Inference triggered to call setindex!(::Vector{Vector{Tuple{Float64, Float64, Float64}}}, ::Vector{Tuple{Float64, Float64, Float64}}, ::Int64) from generate_chunked_partials (C:\Users\accou\.julia\dev\SparseDiffTools\src\differentiation\compute_jacobian_ad.jl:77) with specialization SparseDiffTools.generate_chunked_partials(::Vector{Float64}, ::UnitRange{Int64}, ::Val{3})
 Inference triggered to call OrdinaryDiffEq.jacobian2W!(::Matrix{Float64}, ::LinearAlgebra.UniformScaling{Bool}, ::Float64, ::Matrix{Float64}, ::Bool) called from toplevel
```

@chriselrod or @yingboma could I get some Cthulhu magic to look at what's going on there?
