### PR TITLE
don't fill! on a SparseMatrix

### DIFF
--- a/src/differentiation/compute_jacobian_ad.jl
+++ b/src/differentiation/compute_jacobian_ad.jl
@@ -296,7 +296,11 @@ function forwarddiff_color_jacobian!(J::AbstractMatrix{<:Number},
     color_i = 1
     maxcolor = maximum(colorvec)
 
-    fill!(J, zero(eltype(J)))
+    if J isa SparseMatrixCSC
+        fill!(nonzeros(J), zero(eltype(J)))
+    else
+        fill!(J, zero(eltype(J)))
+    end
 
     if FiniteDiff._use_findstructralnz(sparsity)
         rows_index, cols_index = ArrayInterface.findstructralnz(sparsity)


### PR DESCRIPTION
```julia
julia> x = sprand(2,2,0.5)
2×2 SparseMatrixCSC{Float64, Int64} with 1 stored entry:
 0.507603   ⋅ 
  ⋅         ⋅ 

julia> fill!(x, true)
2×2 SparseMatrixCSC{Float64, Int64} with 4 stored entries:
 1.0  1.0
 1.0  1.0
```

Seems like an issue for Base.