### PR TITLE
Update README `jacobian_sparsity`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,18 +43,17 @@ end
 
 For this function, we know that the sparsity pattern of the Jacobian is a
 `Tridiagonal` matrix. However, if we didn't know the sparsity pattern for
-the Jacobian, we could use the `jacobian_sparsity` function to automatically
-detect the sparsity pattern. This function is only available if you
-load SparsityDetection.jl as well. We declare that the function `f` outputs a
-vector of length 30 and takes in a vector of length 30, and `jacobian_sparsity` spits
-out a `Sparsity` object which we can turn into a `SparseMatrixCSC`:
+the Jacobian, we could use the `Symbolics.jacobian_sparsity` function to automatically
+detect the sparsity pattern. We declare that the function `f` outputs a
+vector of length 30 and takes in a vector of length 30, and `jacobian_sparsity` returns
+a `SparseMatrixCSC`:
 
 ```julia
-using Symbolics, SparseArrays
+using Symbolics
 input = rand(30)
 output = similar(input)
 sparsity_pattern = Symbolics.jacobian_sparsity(f,output,input)
-jac = Float64.(sparse(sparsity_pattern))
+jac = Float64.(sparsity_pattern)
 ```
 
 Now we call `matrix_colors` to get the colorvec vector for that matrix:


### PR DESCRIPTION
close https://github.com/JuliaDiff/SparseDiffTools.jl/issues/193

- Remove SparsityDetection.jl from the text description.
- `Symbolics.jacobian_sparsity` returns a `SparseMatrixCSC`. One doesn't need to call `sparse`.
https://github.com/JuliaSymbolics/Symbolics.jl/blob/e45badffda9bf5e4ba8e76914c171a73a08346c1/src/diff.jl#L527
https://github.com/JuliaSparse/SparseArrays.jl/blob/1bae96dc8f9a8ca8b7879eef4cf71e186598e982/src/sparsematrix.jl#L960
