### PR TITLE
Make the `get_tag` function generic

### DIFF
--- a/src/differentiation/jaches_products.jl
+++ b/src/differentiation/jaches_products.jl
@@ -1,6 +1,6 @@
 struct DeivVecTag end
 
-get_tag(::Array{Dual{T, V, N}}) where {T, V, N} = T
+get_tag(::AbstractArray{Dual{T, V, N}}) where {T, V, N} = T
 get_tag(::Dual{T, V, N}) where {T, V, N} = T
 
 # J(f(x))*v


### PR DESCRIPTION
Fixes https://github.com/JuliaDiff/SparseDiffTools.jl/issues/262