### PR TITLE
Don't use custom tags

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -50,6 +50,9 @@ jobs:
             @info "Not compatible with this release. No problem." exception=err
             exit(0)  # Exit immediately, as a success
           end
+        env:
+          RETESTITEMS_NWORKERS: 4
+          RETESTITEMS_NWORKER_THREADS: 2
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v3
         with:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SparseDiffTools"
 uuid = "47a9eef4-7e08-11e9-0b38-333d64bd3804"
 authors = ["Pankaj Mishra <pankajmishra1511@gmail.com>", "Chris Rackauckas <contact@chrisrackauckas.com>"]
-version = "2.17.0"
+version = "2.17.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/ext/SparseDiffToolsPolyesterForwardDiffExt.jl
+++ b/ext/SparseDiffToolsPolyesterForwardDiffExt.jl
@@ -6,8 +6,7 @@ import SparseDiffTools: AbstractMaybeSparseJacobianCache, AbstractMaybeSparsityD
                         ForwardColorJacCache, NoMatrixColoring, sparse_jacobian_cache,
                         sparse_jacobian!,
                         sparse_jacobian_static_array, __standard_tag, __chunksize,
-                        polyesterforwarddiff_color_jacobian,
-                        polyesterforwarddiff_color_jacobian!
+                        polyesterforwarddiff_color_jacobian
 
 struct PolyesterForwardDiffJacobianCache{CO, CA, J, FX, X} <:
        AbstractMaybeSparseJacobianCache
@@ -27,7 +26,7 @@ function sparse_jacobian_cache(
         cache = __chunksize(ad, x)
         jac_prototype = nothing
     else
-        tag = __standard_tag(nothing, x)
+        tag = __standard_tag(nothing, f, x)
         # Colored ForwardDiff passes `tag` directly into Dual so we need the `typeof`
         cache = ForwardColorJacCache(f, x, __chunksize(ad); coloring_result.colorvec,
             dx = fx, sparsity = coloring_result.jacobian_sparsity, tag = typeof(tag))
@@ -47,7 +46,7 @@ function sparse_jacobian_cache(
         @warn """Currently PolyesterForwardDiff does not support sparsity detection
                  natively for inplace functions. Falling back to using
                 ForwardDiff.jl""" maxlog=1
-        tag = __standard_tag(nothing, x)
+        tag = __standard_tag(nothing, f!, x)
         # Colored ForwardDiff passes `tag` directly into Dual so we need the `typeof`
         cache = ForwardColorJacCache(f!, x, __chunksize(ad); coloring_result.colorvec,
             dx = fx, sparsity = coloring_result.jacobian_sparsity, tag = typeof(tag))


### PR DESCRIPTION
I don't remember why we used them in the first place, but it causes tag ordering issues for higher order AD.