### PR TITLE
Set default `rows_index` and `cols_index` to `nothing`

### DIFF
--- a/src/differentiation/compute_jacobian_ad.jl
+++ b/src/differentiation/compute_jacobian_ad.jl
@@ -348,8 +348,8 @@ function forwarddiff_color_jacobian!(J::AbstractMatrix{<:Number},
     if FiniteDiff._use_findstructralnz(sparsity)
         rows_index, cols_index = ArrayInterface.findstructralnz(sparsity)
     else
-        rows_index = 1:size(J, 1)
-        cols_index = 1:size(J, 2)
+        rows_index = nothing
+        cols_index = nothing
     end
 
     # fast path if J and sparsity are both AbstractSparseMatrix and have the same sparsity pattern


### PR DESCRIPTION
Partial fix for https://github.com/SciML/NonlinearSolve.jl/issues/473

A better solution would be something like this
```julia
julia> using Base.Iterators

julia> using BenchmarkTools

julia> function findstructralnz(x::AbstractMatrix)
           cartind = vec(CartesianIndices(x))
           return Iterators.map(first ∘ Tuple, cartind), Iterators.map(last ∘ Tuple, cartind)
       end
findstructralnz (generic function with 1 method)

julia> collect.(findstructralnz(rand(2, 3)))
([1, 2, 1, 2, 1, 2], [1, 1, 2, 2, 3, 3])

julia> @btime findstructralnz($(rand(2, 3)));
  28.162 ns (0 allocations: 0 bytes)
```

But for some reason we don't have code coverage information for this repo, so I'm not even sure this branch is getting hit in tests. Better err on the side of caution until that changes.